### PR TITLE
AppKey 가이드 문구 수정

### DIFF
--- a/en/api-guide.md
+++ b/en/api-guide.md
@@ -3,13 +3,12 @@
 
 > To check permissions using the ROLE service, call the RESTful API or use the Client SDK.
 
-## AppKey & SecretKey
+## Authentication and Authorization 
 
-AppKey and Secret Key are required to use RESTful API and Client SDK.
-You can check the issued key information by clicking the **URL & Appkey** button on the top right of the [CONSOLE].
-
-![[Figure 1] Check AppKey & SecretKey](http://static.toastoven.net/prod_role/role_60.png)
-<center>[Figure 1] Check AppKey &amp; SecretKey</center>
+AppKey and SecretKey are required to use the ROLE API.
+The Appkey is included in the request URL to identify and specify a particular resource when making API calls. A SecretKey is a private key used to control access to the API. 
+For more information on checking and using Appkeys and SecretKeys, please refer to [Appkey](/nhncloud/en/public-api/appkey).
+Alternatively, a Project-integrated Appkey can be used in place of Appkey. For more information on creating and using Project Integrated Appkeys, please refer to [Project Integrated Appkey](/nhncloud/en/public-api/project-integrated-appkey).
 
 ## RESTful API Guide
 

--- a/en/api-v3-guide.md
+++ b/en/api-v3-guide.md
@@ -3,13 +3,12 @@
 > To check the permissions to use the ROLE service, call RESTful API or use Client SDK.
 > Call RESTful APIs or use client SDKs.
 
-## AppKey & SecretKey
+## Authentication and Authorization 
 
-AppKey and Secret Key are required to use RESTful API and Client SDK.
-You can check the issued key information by clicking the **URL & Appkey** button on the top right of the [CONSOLE].
-
-![[Figure 1] Check AppKey & SecretKey](http://static.toastoven.net/prod_role/role_60.png)
-<center>[Figure 1] Check AppKey &amp; SecretKey</center>
+AppKey and SecretKey are required to use the ROLE API.
+The Appkey is included in the request URL to identify and specify a particular resource when making API calls. A SecretKey is a private key used to control access to the API. 
+For more information on checking and using Appkeys and SecretKeys, please refer to [Appkey](/nhncloud/en/public-api/appkey).
+Alternatively, a Project-integrated Appkey can be used in place of Appkey. For more information on creating and using Project Integrated Appkeys, please refer to [Project Integrated Appkey](/nhncloud/en/public-api/project-integrated-appkey).
 
 ## RESTful API Guide
 

--- a/en/sdk-guide.md
+++ b/en/sdk-guide.md
@@ -7,7 +7,7 @@
 
 ## 인증 및 권한
 
-ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+ROLE SDK를 사용하려면 Appkey와 SecretKey가 필요합니다.
 Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
 Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
 Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.

--- a/en/sdk-guide.md
+++ b/en/sdk-guide.md
@@ -5,13 +5,12 @@
 > RESTFUL API 를 호출하거나, Client SDK 를 이용하여야 한다.
 > Spring Framework 을 사용하는 경우, 좀더 편하게 JAVA Client SDK 를 사용할 수 있다.
 
-## 앱키 & 비밀 키
+## 인증 및 권한
 
-RESTFUL API 와 Client SDK 를 사용하려면 앱키와 비밀 키가 필요하다.
-[CONSOLE] 의 좌측 상단에서 발급된 Key 정보를 확인 할 수 있다.
-
-![[그림 1] 앱키 & 비밀 키 확인](http://static.toastoven.net/prod_role/role_60.png)
-<center>[그림 1] 앱키 & 비밀 키 확인</center>
+ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
+Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
+Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.
 
 
 ## Spring Client SDK

--- a/en/sdk-v2-guide.md
+++ b/en/sdk-v2-guide.md
@@ -5,7 +5,7 @@
 
 ## Authentication and Authorization 
 
-AppKey and SecretKey are required to use the ROLE API.
+AppKey and SecretKey are required to use the ROLE SDK.
 The Appkey is included in the request URL to identify and specify a particular resource when making API calls. A SecretKey is a private key used to control access to the API. 
 For more information on checking and using Appkeys and SecretKeys, please refer to [Appkey](/nhncloud/en/public-api/appkey).
 Alternatively, a Project-integrated Appkey can be used in place of Appkey. For more information on creating and using Project Integrated Appkeys, please refer to [Project Integrated Appkey](/nhncloud/en/public-api/project-integrated-appkey).

--- a/en/sdk-v2-guide.md
+++ b/en/sdk-v2-guide.md
@@ -3,13 +3,12 @@
 > In order to check authority using the ROLE service, 
 > the RESTful API have to be called or the client SDK have to be used.
 
-## AppKey & SecretKey
+## Authentication and Authorization 
 
-AppKey and SecretKey are required to use RESTful API and Client SDK.
-You can check the key information issued at the top left of [CONSOLE].
-
-![[Figure 1] Check AppKey and SecretKey](http://static.toastoven.net/prod_role/role_60.png)
-<center>[Figure 1] Check AppKey and SecretKey</center>
+AppKey and SecretKey are required to use the ROLE API.
+The Appkey is included in the request URL to identify and specify a particular resource when making API calls. A SecretKey is a private key used to control access to the API. 
+For more information on checking and using Appkeys and SecretKeys, please refer to [Appkey](/nhncloud/en/public-api/appkey).
+Alternatively, a Project-integrated Appkey can be used in place of Appkey. For more information on creating and using Project Integrated Appkeys, please refer to [Project Integrated Appkey](/nhncloud/en/public-api/project-integrated-appkey).
 
 ## Client SDK
 

--- a/ja/api-guide.md
+++ b/ja/api-guide.md
@@ -4,13 +4,12 @@
 > ROLEサービスを利用して権限をチェックするためには
 > RESTful APIを呼び出すか、クライアントSDKを利用する必要があります。
 
-## アプリケーションキー&秘密鍵
+## 認証および権限
 
-RESTful APIとクライアントSDKを使用するには、アプリケーションキーと秘密鍵が必要です。
-[CONSOLE] 右上の**URL & Appkey**ボタンをクリックすると、発行キー情報を確認できます。
-
-![[図1]アプリケーションキー&秘密鍵確認](http://static.toastoven.net/prod_role/role_60.png)
-<center>[図1]アプリケーションキー&秘密鍵の確認</center>
+ROLE APIを使用するには、AppkeyとSecretKeyが必要です。
+Appkeyは、API呼び出し時にリクエストURLに含めて特定のリソースを指定し、識別するために使用されます。SecretKeyは、APIへのアクセスを制御するシークレットキーです。
+Appkey及びSecretKeyの確認及び使用に関する詳細は、[Appkey](/nhncloud/ja/public-api/appkey)を参照してください。
+Appkeyの代わりにプロジェクト統合Appkeyを使用することも可能です。プロジェクト統合Appkeyの作成及び使用に関する詳細は、[プロジェクト統合Appkey](/nhncloud/ja/public-api/project-integrated-appkey)を参照してください。
 
 ## RESTful APIガイド
 

--- a/ja/api-v3-guide.md
+++ b/ja/api-v3-guide.md
@@ -3,13 +3,12 @@
 > ROLEサービスを利用して権限をチェックするためには
 > RESTful APIを呼び出すか、クライアントSDKを利用する必要があります。
 
-## アプリケーションキー&秘密鍵
+## 認証および権限
 
-RESTful APIとクライアントSDKを使用するには、アプリケーションキーと秘密鍵が必要です。
-[CONSOLE] 右上の**URL & Appkey**ボタンをクリックすると、発行キー情報を確認できます。
-
-![[図1]アプリケーションキー&秘密鍵確認](http://static.toastoven.net/prod_role/role_60.png)
-<center>[図1]アプリケーションキー&秘密鍵の確認</center>
+ROLE APIを使用するには、AppkeyとSecretKeyが必要です。
+Appkeyは、API呼び出し時にリクエストURLに含めて特定のリソースを指定し、識別するために使用されます。SecretKeyは、APIへのアクセスを制御するシークレットキーです。
+Appkey及びSecretKeyの確認及び使用に関する詳細は、[Appkey](/nhncloud/ja/public-api/appkey)を参照してください。
+Appkeyの代わりにプロジェクト統合Appkeyを使用することも可能です。プロジェクト統合Appkeyの作成及び使用に関する詳細は、[プロジェクト統合Appkey](/nhncloud/ja/public-api/project-integrated-appkey)を参照してください。
 
 ## RESTful APIガイド
 

--- a/ja/sdk-guide.md
+++ b/ja/sdk-guide.md
@@ -7,7 +7,7 @@
 
 ## 인증 및 권한
 
-ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+ROLE SDK를 사용하려면 Appkey와 SecretKey가 필요합니다.
 Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
 Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
 Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.

--- a/ja/sdk-guide.md
+++ b/ja/sdk-guide.md
@@ -5,13 +5,12 @@
 > RESTFUL API 를 호출하거나, Client SDK 를 이용하여야 한다.
 > Spring Framework 을 사용하는 경우, 좀더 편하게 JAVA Client SDK 를 사용할 수 있다.
 
-## 앱키 & 비밀 키
+## 인증 및 권한
 
-RESTFUL API 와 Client SDK 를 사용하려면 앱키와 비밀 키가 필요하다.
-[CONSOLE] 의 좌측 상단에서 발급된 Key 정보를 확인 할 수 있다.
-
-![[그림 1] 앱키 & 비밀 키 확인](http://static.toastoven.net/prod_role/role_60.png)
-<center>[그림 1] 앱키 & 비밀 키 확인</center>
+ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
+Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
+Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.
 
 
 ## Spring Client SDK

--- a/ja/sdk-v2-guide.md
+++ b/ja/sdk-v2-guide.md
@@ -3,13 +3,12 @@
 > ROLEサービスを利用して権限をチェックするためには
 > RESTful APIを呼び出すか、クライアントSDKを利用する必要があります。
 
-## アプリケーションキー&秘密鍵
+## 認証および権限
 
-RESTful APIとクライアントSDKを使用するには、アプリケーションキーと秘密鍵が必要です。 
-[CONSOLE]の右上で発行されたキー情報を確認できます。
-
-![[図1]アプリケーションキー&秘密鍵の確認](http://static.toastoven.net/prod_role/role_60.png)
-<center>[図1]アプリケーションキー&秘密鍵の確認</center>
+ROLE APIを使用するには、AppkeyとSecretKeyが必要です。
+Appkeyは、API呼び出し時にリクエストURLに含めて特定のリソースを指定し、識別するために使用されます。SecretKeyは、APIへのアクセスを制御するシークレットキーです。
+Appkey及びSecretKeyの確認及び使用に関する詳細は、[Appkey](/nhncloud/ja/public-api/appkey)を参照してください。
+Appkeyの代わりにプロジェクト統合Appkeyを使用することも可能です。プロジェクト統合Appkeyの作成及び使用に関する詳細は、[プロジェクト統合Appkey](/nhncloud/ja/public-api/project-integrated-appkey)を参照してください。
 
 ## クライアントSDK
 

--- a/ja/sdk-v2-guide.md
+++ b/ja/sdk-v2-guide.md
@@ -5,7 +5,7 @@
 
 ## 認証および権限
 
-ROLE APIを使用するには、AppkeyとSecretKeyが必要です。
+ROLE SDKを使用するには、AppkeyとSecretKeyが必要です。
 Appkeyは、API呼び出し時にリクエストURLに含めて特定のリソースを指定し、識別するために使用されます。SecretKeyは、APIへのアクセスを制御するシークレットキーです。
 Appkey及びSecretKeyの確認及び使用に関する詳細は、[Appkey](/nhncloud/ja/public-api/appkey)を参照してください。
 Appkeyの代わりにプロジェクト統合Appkeyを使用することも可能です。プロジェクト統合Appkeyの作成及び使用に関する詳細は、[プロジェクト統合Appkey](/nhncloud/ja/public-api/project-integrated-appkey)を参照してください。

--- a/ko/api-guide.md
+++ b/ko/api-guide.md
@@ -4,13 +4,12 @@
 > ROLE 서비스를 이용해 권한을 체크하기 위해서는
 > RESTful API를 호출하거나, 클라이언트 SDK를 이용하여야 합니다.
 
-## 앱키 & 비밀 키
+## 인증 및 권한
 
-RESTful API와 클라이언트 SDK를 사용하려면 앱키와 비밀 키가 필요합니다.
-[CONSOLE] 우측 상단의 **URL & Appkey** 버튼을 클릭하여 발급 키 정보를 확인할 수 있습니다.
-
-![[그림 1] 앱키 & 비밀 키 확인](http://static.toastoven.net/prod_role/role_60.png)
-<center>[그림 1] 앱키 & 비밀 키 확인</center>
+ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
+Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
+Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.
 
 ## RESTful API 가이드
 

--- a/ko/api-v3-guide.md
+++ b/ko/api-v3-guide.md
@@ -3,13 +3,12 @@
 > ROLE 서비스를 사용해 권한을 확인하려면
 > RESTful API를 호출하거나, 클라이언트 SDK를 사용해야 합니다.
 
-## 앱키 & 비밀 키
+## 인증 및 권한
 
-RESTful API와 클라이언트 SDK를 사용하려면 앱키와 비밀 키가 필요합니다.
-[콘솔] 오른쪽 위의 **URL & Appkey** 버튼을 클릭하여 발급된 키 정보를 확인할 수 있습니다.
-
-![[그림 1] 앱키 & 비밀 키 확인](http://static.toastoven.net/prod_role/role_60.png)
-<center>[그림 1] 앱키 & 비밀 키 확인</center>
+ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
+Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
+Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.
 
 ## RESTful API 가이드
 

--- a/ko/sdk-guide.md
+++ b/ko/sdk-guide.md
@@ -7,7 +7,7 @@
 
 ## 인증 및 권한
 
-ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+ROLE SDK를 사용하려면 Appkey와 SecretKey가 필요합니다.
 Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
 Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
 Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.

--- a/ko/sdk-guide.md
+++ b/ko/sdk-guide.md
@@ -5,13 +5,12 @@
 > RESTFUL API 를 호출하거나, Client SDK 를 이용하여야 한다.
 > Spring Framework 을 사용하는 경우, 좀더 편하게 JAVA Client SDK 를 사용할 수 있다.
 
-## 앱키 & 비밀 키
+## 인증 및 권한
 
-RESTFUL API 와 Client SDK 를 사용하려면 앱키와 비밀 키가 필요하다.
-[CONSOLE] 의 좌측 상단에서 발급된 Key 정보를 확인 할 수 있다.
-
-![[그림 1] 앱키 & 비밀 키 확인](http://static.toastoven.net/prod_role/role_60.png)
-<center>[그림 1] 앱키 & 비밀 키 확인</center>
+ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
+Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
+Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.
 
 
 ## Spring Client SDK

--- a/ko/sdk-v2-guide.md
+++ b/ko/sdk-v2-guide.md
@@ -5,7 +5,7 @@
 
 ## 인증 및 권한
 
-ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+ROLE SDK를 사용하려면 Appkey와 SecretKey가 필요합니다.
 Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
 Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
 Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.

--- a/ko/sdk-v2-guide.md
+++ b/ko/sdk-v2-guide.md
@@ -3,13 +3,12 @@
 > ROLE 서비스를 사용하여 권한을 확인하려면
 > RESTful API를 호출하거나, 클라이언트 SDK를 사용해야 합니다.
 
-## 앱키 & 비밀 키
+## 인증 및 권한
 
-RESTful API와 클라이언트 SDK를 사용하려면 앱키와 비밀 키가 필요합니다.
-[콘솔]의 오른쪽 위 **URL & Appkey** 버튼을 클릭하여 발급된 키 정보를 확인할 수 있습니다.
-
-![[그림 1] 앱키 & 비밀 키 확인](http://static.toastoven.net/prod_role/role_60.png)
-<center>[그림 1] 앱키 & 비밀 키 확인</center>
+ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
+Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
+Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.
 
 ## 클라이언트 SDK
 

--- a/zh/api-guide.md
+++ b/zh/api-guide.md
@@ -4,13 +4,12 @@
 > ROLE 서비스를 이용해 권한을 체크하기 위해서는
 > RESTful API를 호출하거나, 클라이언트 SDK를 이용하여야 합니다.
 
-## 앱키 & 비밀 키
+## 인증 및 권한
 
-RESTful API와 클라이언트 SDK를 사용하려면 앱키와 비밀 키가 필요합니다.
-[CONSOLE] 우측 상단의 **URL & Appkey** 버튼을 클릭하여 발급 키 정보를 확인할 수 있습니다.
-
-![[그림 1] 앱키 & 비밀 키 확인](http://static.toastoven.net/prod_role/role_60.png)
-<center>[그림 1] 앱키 & 비밀 키 확인</center>
+ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
+Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
+Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.
 
 ## RESTful API 가이드
 

--- a/zh/api-v3-guide.md
+++ b/zh/api-v3-guide.md
@@ -3,13 +3,12 @@
 > ROLE 서비스를 이용해 권한을 체크하기 위해서는
 > RESTful API를 호출하거나, 클라이언트 SDK를 이용하여야 합니다.
 
-## 앱키 & 비밀 키
+## 인증 및 권한
 
-RESTful API와 클라이언트 SDK를 사용하려면 앱키와 비밀 키가 필요합니다.
-[CONSOLE] 우측 상단의 **URL & Appkey** 버튼을 클릭하여 발급 키 정보를 확인 할 수 있습니다.
-
-![[그림 1] 앱키 & 비밀 키 확인](http://static.toastoven.net/prod_role/role_60.png)
-<center>[그림 1] 앱키 & 비밀 키 확인</center>
+ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
+Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
+Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.
 
 ## RESTful API 가이드
 

--- a/zh/sdk-guide.md
+++ b/zh/sdk-guide.md
@@ -7,7 +7,7 @@
 
 ## 인증 및 권한
 
-ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+ROLE SDK를 사용하려면 Appkey와 SecretKey가 필요합니다.
 Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
 Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
 Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.

--- a/zh/sdk-guide.md
+++ b/zh/sdk-guide.md
@@ -5,13 +5,12 @@
 > RESTFUL API 를 호출하거나, Client SDK 를 이용하여야 한다.
 > Spring Framework 을 사용하는 경우, 좀더 편하게 JAVA Client SDK 를 사용할 수 있다.
 
-## 앱키 & 비밀 키
+## 인증 및 권한
 
-RESTFUL API 와 Client SDK 를 사용하려면 앱키와 비밀 키가 필요하다.
-[CONSOLE] 의 좌측 상단에서 발급된 Key 정보를 확인 할 수 있다.
-
-![[그림 1] 앱키 & 비밀 키 확인](http://static.toastoven.net/prod_role/role_60.png)
-<center>[그림 1] 앱키 & 비밀 키 확인</center>
+ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
+Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
+Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.
 
 
 ## Spring Client SDK

--- a/zh/sdk-v2-guide.md
+++ b/zh/sdk-v2-guide.md
@@ -5,7 +5,7 @@
 
 ## 인증 및 권한
 
-ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+ROLE SDK를 사용하려면 Appkey와 SecretKey가 필요합니다.
 Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
 Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
 Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.

--- a/zh/sdk-v2-guide.md
+++ b/zh/sdk-v2-guide.md
@@ -3,13 +3,12 @@
 > ROLE 서비스를 이용하여 권한을 체크하기 위해서는
 > RESTful API를 호출하거나, 클라이언트 SDK를 이용해야 합니다.
 
-## 앱키 & 비밀 키
+## 인증 및 권한
 
-RESTful API와 클라이언트 SDK를 사용하려면 앱키와 비밀 키가 필요합니다. 
-[CONSOLE]의 우측 상단에서 발급된 키 정보를 확인할 수 있습니다.
-
-![[그림 1] 앱키 & 비밀 키 확인](http://static.toastoven.net/prod_role/role_60.png)
-<center>[그림 1] 앱키 & 비밀 키 확인</center>
+ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
+Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
+Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
+Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.
 
 ## 클라이언트 SDK
 


### PR DESCRIPTION
지난 2월 Public API 사용 가이드가 개편되면서 서비스마다 지원하고 있는 API 인증 방법을 공통 문서로 작성하고, 각 서비스의 API 가이드에서는 해당 공통 문서를 참조하는 방식으로 설명을 제공하고자 하는데요. ROLE은 Appkey와 프로젝트 통합 Appkey를 제공하고 있는 것으로 보여 아래 가이드에서 5. Appkey와 프로젝트 통합 Appkey를 모두 지원하는 서비스 API 가이드의 문구를 API 가이드 도입부에 적용해 주실 수 있을까요? https://nhnent.dooray.com/share/pages/mtAcooUcTqiXTduAkzusQw/4226296481254495408


[KO]
ROLE API를 사용하려면 Appkey와 SecretKey가 필요합니다.
Appkey는 API 호출 시 요청 URL에 포함하여 특정 리소스를 가리키고 식별하는 데 사용되며, SecretKey는 API에 대한 접근을 제어하는 비밀 키입니다.
Appkey 및 SecretKey 확인 및 사용에 대한 자세한 내용은 [Appkey](/nhncloud/ko/public-api/appkey)를 참고하세요.
Appkey 대신 프로젝트 통합 Appkey를 사용할 수도 있습니다. 프로젝트 통합 Appkey에 대한 자세한 내용은 [프로젝트 통합 Appkey](/nhncloud/ko/public-api/project-integrated-appkey)를 참고하세요.

[EN]
AppKey and SecretKey are required to use the ROLE API.
The Appkey is included in the request URL to identify and specify a particular resource when making API calls. A SecretKey is a private key used to control access to the API. 
For more information on checking and using Appkeys and SecretKeys, please refer to [Appkey](/nhncloud/en/public-api/appkey).
Alternatively, a Project-integrated Appkey can be used in place of Appkey. For more information on creating and using Project Integrated Appkeys, please refer to [Project Integrated Appkey](/nhncloud/en/public-api/project-integrated-appkey).

[JA]
ROLE APIを使用するには、AppkeyとSecretKeyが必要です。
Appkeyは、API呼び出し時にリクエストURLに含めて特定のリソースを指定し、識別するために使用されます。SecretKeyは、APIへのアクセスを制御するシークレットキーです。
Appkey及びSecretKeyの確認及び使用に関する詳細は、[Appkey](/nhncloud/ja/public-api/appkey)を参照してください。
Appkeyの代わりにプロジェクト統合Appkeyを使用することも可能です。プロジェクト統合Appkeyの作成及び使用に関する詳細は、[プロジェクト統合Appkey](/nhncloud/ja/public-api/project-integrated-appkey)を参照してください。

기존 앱키&비밀 키 헤더를 인증 및 권한, Authentication and Authorization, 認証および権限으로 변경 후 위 문구를 적용 부탁드리겠습니다.